### PR TITLE
Add support for great spells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.java
 *.json
+*.pickle
 __pycache__

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
    * https://github.com/gamma-delta/HexMod/blob/main/Common/src/main/resources/assets/hexcasting/lang/en_us.json (or whatever your preferred language is)
 * Build the pattern registry:
 ```
-python buildpatterns.py pattern_registry.json *.java
+python buildpatterns.py pattern_registry.pickle *.java
 ```
 
 # Usage
@@ -24,17 +24,17 @@ python buildpatterns.py pattern_registry.json *.java
 * Open `.minecraft/logs/latest.log`, find the Reveal output, and copy it (should look like `[HexPattern(NORTH_EAST qaq)]`).
 * Open a terminal in the repository folder and submit your hex:
 ```
-echo "paste your hex here" | python hexdecode.py pattern_registry.json
+echo "paste your hex here" | python hexdecode.py pattern_registry.pickle
 ```
 * If you'd like the fanciful names rather than the internal ones, do this instead:
 ```
-echo "paste your hex here" | python hexdecode.py pattern_registry.json en_us.json
+echo "paste your hex here" | python hexdecode.py pattern_registry.pickle en_us.json
 ```
 * To get syntax highlighting:
 ```
-echo "paste your hex here" | python hexdecode.py pattern_registry.json en_us.json --highlight
+echo "paste your hex here" | python hexdecode.py pattern_registry.pickle en_us.json --highlight
 ```
 * Here's a useful thing if you're on a Mac. This takes the clipboard, decodes it, and puts the result back onto the clipboard for pasting:
 ```
-pbpaste | python hexdecode.py pattern_registry.json en_us.json | pbcopy
+pbpaste | python hexdecode.py pattern_registry.pickle en_us.json | pbcopy
 ```

--- a/buildpatterns.py
+++ b/buildpatterns.py
@@ -2,7 +2,7 @@ import re
 import pickle
 import sys
 import glob
-from hexast import Direction, get_rotated_line_midpoints, PatternRegistry
+from hexast import Direction, get_rotated_pattern_segments, PatternRegistry
 
 # working as of https://github.com/gamma-delta/HexMod/blob/c00815b7b9d90593dc33e3a7539ce87c2ece4fc9/Common/src/main/java/at/petrak/hexcasting/common/casting/RegisterPatterns.java
 # - go to https://github.com/gamma-delta/HexMod/blob/main/Common/src/main/java/at/petrak/hexcasting/common/casting/RegisterPatterns.java
@@ -20,8 +20,8 @@ for path in sys.argv[2:]:
             for match in registry_regex.finditer(file.read()):
                 (pattern, direction, name, is_great) = match.groups()
                 if is_great:
-                    for points in get_rotated_line_midpoints(Direction[direction], pattern):
-                        registry.great_spells[points] = name
+                    for segments in get_rotated_pattern_segments(Direction[direction], pattern):
+                        registry.great_spells[segments] = name
                 else:
                     registry.spells[pattern] = name
 

--- a/buildpatterns.py
+++ b/buildpatterns.py
@@ -1,7 +1,8 @@
 import re
-import json
+import pickle
 import sys
 import glob
+from hexast import Direction, get_rotated_line_midpoints, PatternRegistry
 
 # working as of https://github.com/gamma-delta/HexMod/blob/c00815b7b9d90593dc33e3a7539ce87c2ece4fc9/Common/src/main/java/at/petrak/hexcasting/common/casting/RegisterPatterns.java
 # - go to https://github.com/gamma-delta/HexMod/blob/main/Common/src/main/java/at/petrak/hexcasting/common/casting/RegisterPatterns.java
@@ -9,18 +10,22 @@ import glob
 #   - note: you'll have to do this again after each update, if new patterns are added or old patterns are changed
 
 output_file = sys.argv[1]
-registry = re.compile(r"PatternRegistry\s*\.\s*mapPattern\s*\(\s*HexPattern\s*\.\s*fromAngles\s*\(\s*\"([aqwed]+)\"\s*,\s*HexDir\s*\.\s*\w+\s*\)\s*,\s*modLoc\s*\(\s*\"([\w/]+)\"\s*\)", re.M)
+registry_regex = re.compile(r"PatternRegistry\s*\.\s*mapPattern\s*\(\s*HexPattern\s*\.\s*fromAngles\s*\(\s*\"([aqwed]+)\"\s*,\s*HexDir\s*\.\s*(\w+)\s*\)\s*,\s*modLoc\s*\(\s*\"([\w/]+)\"\s*\).+?(true)?\);", re.M | re.S)
 
 # parse the pattern definitions
-pattern_lookup = {}
+registry = PatternRegistry()
 for path in sys.argv[2:]:
     for filename in glob.glob(path):
         with open(filename, "r", encoding="utf-8") as file:
-            for match in registry.finditer(file.read()):
-                (pattern, name) = match.groups()
-                pattern_lookup[pattern] = name
+            for match in registry_regex.finditer(file.read()):
+                (pattern, direction, name, is_great) = match.groups()
+                if is_great:
+                    for points in get_rotated_line_midpoints(Direction[direction], pattern):
+                        registry.great_spells[points] = name
+                else:
+                    registry.spells[pattern] = name
 
-with open(output_file, "w", encoding="utf-8") as file:
-    json.dump(pattern_lookup, file)
+with open(output_file, "wb") as file:
+    pickle.dump(registry, file)
 
 print(f"Successfully wrote pattern registry to {output_file}")


### PR DESCRIPTION
This checks great spells by getting the (axial) coordinates of the midpoint of each line in the pattern, translating them so the centre is at the origin, and checking against a list in the pattern registry. The pattern registry has 6 entries for each great spell, one for each starting direction.

This needs more testing. Can you run your spellbook through it and see if anything breaks?

Is the output formatting fine? wiresegal suggested adding a `?` at the end of great spells to signify that we don't know if that's the correct pattern for a given world. I also thought about showing the angle signature in brackets. Neither is currently in this PR.